### PR TITLE
Execute zsh script with zsh

### DIFF
--- a/fetch_mon
+++ b/fetch_mon
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 
 #
 # Zsh script for looping the coinmon command on your desired coins


### PR DESCRIPTION
The comment says that this is a zsh script, but then it is executed with the
bourne shell (sh). Also `#!/usr/bin/env zsh` should be used over `'!/bin/zsh`,
because it works independently of the position of the zsh executable on the
file system, as long as zsh is on the path. This is also done for money.py.