### PR TITLE
List fix

### DIFF
--- a/fetch_mon
+++ b/fetch_mon
@@ -5,12 +5,12 @@
 # Author: Jasper Haasdijk
 #
 
-coins="BTC,ETH,BCH,MIOTA,DASH,XMR,QTUM,XLM,ZEC,XRB,OMG,WAVES,PPT,SALT,DCR,MAID"
+coins=(BTC ETH BCH MIOTA DASH XMR QTUM XLM ZEC XRB OMG WAVES PPT SALT DCR MAID)
 
 while true
 do
   clear
-  coinmon -f $coins
+  coinmon -f ${(j:,:)coins}
   sleep 1200
 done
 

--- a/fetch_mon
+++ b/fetch_mon
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 
 #
 # Zsh script for looping the coinmon command on your desired coins


### PR DESCRIPTION
Arrays are more readable, and easier to manipulate. This is "the zsh way" of doing things.

Note that https://github.com/jhaasdijk/Coincommand/pull/1 must be merged first, because this is a zsh feature, but the script as it stands on master right now uses the bourne shell. 